### PR TITLE
Implement add to cli interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ to control behavior for each test:
 Usage: <implementation_binary> <command> [options]
 
 Options:
-  -V, --version                    output the version number
+  -V, --version                    Output the version number
   -d, --headers <headers>          A list of header names, optionally quoted
+  -a, --add <header>               Add a (Signature|Authorization) header
   -k, --keyId <keyId>              A Key Id string.
   -p, --private-key <privateKey>   A private key file name filename.
   -t, --key-type <keyType>         The type of the keys.
@@ -38,7 +39,7 @@ Options:
   -a, --algorithm <algorithm>      One of: rsa-sha1, hmac-sha1, rsa-sha256, hmac-sha256, hs2019.
   -c, --created <created>          The created param for the signature.
   -e, --expires <expires>          The expires param for the signature.
-  -h, --help                       output usage information
+  -h, --help                       Output usage information
 
 Modes:
   canonicalize

--- a/test/latest/20-sign.js
+++ b/test/latest/20-sign.js
@@ -14,6 +14,7 @@ const rsaKeyType = 'rsa';
 function commonOptions(options) {
   options.args['private-key'] = rsaPrivateKey;
   options.args['headers'] = 'digest';
+  options.args['add'] = 'Authorization';
   options.args['algorithm'] = 'hs2019';
   options.args['key-type'] = rsaKeyType;
   options.args['keyId'] = 'test';

--- a/test/latest/30-verify.js
+++ b/test/latest/30-verify.js
@@ -11,6 +11,7 @@ const commonKey = path.join(__dirname, '..', 'keys', 'rsa.pub');
 function commonOptions(ops) {
   ops.args['public-key'] = commonKey;
   ops.args['headers'] = ['host', 'digest'];
+  ops.args['add'] = 'Signature';
   ops.args['algorithm'] = 'hs2019';
   ops.args['key-type'] = 'rsa';
   ops.args['keyId'] = 'test';


### PR DESCRIPTION
Adds an option to add a Header to the response.

Addresses: https://github.com/w3c-dvcg/http-signatures-test-suite/issues/8

@liamdennehy this PR adds a basic add option to the README, but does not actually handle all the tests add enables. 