### PR TITLE
Move validators to verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "homepage": "https://github.com/w3c-dvcg/http-signatures-test-suite#readme",
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
-    "eslint-config-digitalbazaar": "^2.0.0",
-    "eslint-plugin-jsdoc": "^4.8.3",
+    "eslint": "^7.14.0",
+    "eslint-config-digitalbazaar": "^2.6.1",
+    "eslint-plugin-jsdoc": "^30.7.8",
     "handlebars": "^4.1.2",
     "mocha": "^6.1.4"
   },

--- a/test/ImplementationReporter.js
+++ b/test/ImplementationReporter.js
@@ -9,7 +9,7 @@ exports = module.exports = ImplementationReporter;
  * Custom Mocha Reporter for w3c test suites.
  *
  * @param {Function} runner - A mocha runner.
- * @param {Object} options - The command line options passed to mocha.
+ * @param {object} options - The command line options passed to mocha.
  */
 function ImplementationReporter(runner, options) {
   mocha.reporters.Base.call(this, runner, options);

--- a/test/latest/10-canonicalize.js
+++ b/test/latest/10-canonicalize.js
@@ -1,6 +1,5 @@
 const config = require('../../config.json');
 const util = require('./util');
-const {algorithms} = require('./input/algorithms');
 const {expect} = require('chai');
 
 describe('Canonicalize', function() {
@@ -247,32 +246,6 @@ describe('Canonicalize', function() {
       });
       ['created', 'expires']
         .forEach(param => {
-          algorithms.forEach(algorithm => {
-            const algTest = `If (${param}) is in headers & the ` +
-            `algorithm param starts with ${algorithm}` +
-            ' MUST produce an error.';
-            it(algTest, async function() {
-              /**
-               * If the header field name is `(created)` and the `algorithm`
-               * parameter starts with `rsa`, `hmac`, or `ecdsa`
-               * an implementation MUST produce an error.
-              */
-              /**
-               * If the header field name is `(expires)` and the `algorithm`
-               * parameter starts with `rsa`, `hmac`, or `ecdsa`
-               * an implementation MUST produce an error.
-              */
-              generatorOptions.args.headers = [`(${algorithm})`];
-              let error = null;
-              try {
-                await util.generate(
-                  `created-${algorithm}`, generatorOptions);
-              } catch(e) {
-                error = e;
-              }
-              expect(error, 'expected an error').to.exist;
-            });
-          });
           const unDefined = `If the '${param}' Signature Parameter is
           not specified, an implementation MUST produce an error.`;
           it(unDefined, async function() {
@@ -294,31 +267,6 @@ describe('Canonicalize', function() {
               error = e;
             }
             expect(error, 'expected and error to be thrown').to.exist;
-          });
-          const notInt = `If the ${param} Signature Parameter is
-          not an integer or unix timestamp, an
-          implementation MUST produce an error.`;
-          it(notInt, async function() {
-            /**
-              * If the `created` Signature Parameter is
-              * not specified, or is not an integer, an implementation MUST
-              * produce an error.
-            */
-            /**
-              * If the `expires` Signature Parameter is
-              * not specified, or is not an integer, an implementation MUST
-              * produce an error.
-            */
-            generatorOptions.args.headers = [`(${param})`];
-            generatorOptions.args[param] = 'not-an-integer';
-            let error = null;
-            try {
-              await util.generate(
-                'basic-request', generatorOptions);
-            } catch(e) {
-              error = e;
-            }
-            expect(error, 'Expected an error to be thrown').to.exist;
           });
           it(`If given valid options SHOULD return '(${param})'.`,
             async function() {

--- a/test/latest/10-canonicalize.js
+++ b/test/latest/10-canonicalize.js
@@ -1,6 +1,7 @@
 const config = require('../../config.json');
 const util = require('./util');
 const {expect} = require('chai');
+const {algorithms} = require('./input/algorithms');
 
 describe('Canonicalize', function() {
   let generatorOptions = null;
@@ -246,6 +247,33 @@ describe('Canonicalize', function() {
       });
       ['created', 'expires']
         .forEach(param => {
+
+          algorithms.forEach(algorithm => {
+            const algTest = `If (${param}) is in headers & the ` +
+            `algorithm param starts with ${algorithm}` +
+            ' MUST produce an error.';
+            it(algTest, async function() {
+              /**
+               * If the header field name is `(created)` and the `algorithm`
+               * parameter starts with `rsa`, `hmac`, or `ecdsa`
+               * an implementation MUST produce an error.
+              */
+              /**
+               * If the header field name is `(expires)` and the `algorithm`
+               * parameter starts with `rsa`, `hmac`, or `ecdsa`
+               * an implementation MUST produce an error.
+              */
+              generatorOptions.args.headers = [`(${algorithm})`];
+              let error = null;
+              try {
+                await util.generate(
+                  `created-${algorithm}`, generatorOptions);
+              } catch(e) {
+                error = e;
+              }
+              expect(error, 'expected an error').to.exist;
+            });
+          });
           const unDefined = `If the '${param}' Signature Parameter is
           not specified, an implementation MUST produce an error.`;
           it(unDefined, async function() {

--- a/test/latest/20-sign.js
+++ b/test/latest/20-sign.js
@@ -128,41 +128,6 @@ describe('Sign', function() {
     });
   });
 
-  it(`MUST NOT process a Signature with a
-      created timestamp value that is in the future.`, async function() {
-    /**
-     * A signature with a `created` timestamp value
-     * that is in the future MUST NOT be processed.
-    */
-    let error = null;
-    const options = commonOptions(generatorOptions);
-    options.args['headers'] = 'date';
-    options.args['created'] = util.getUnixTime() + 1000;
-    try {
-      await util.generate('default-test', options);
-    } catch(e) {
-      error = e;
-    }
-    expect(error, 'Expected an Error').to.not.be.null;
-  });
-
-  it(`MUST NOT process a Signature with an expires
-      timestamp value that is in the past.`, async function() {
-    /**
-      * A signatures with a `expires` timestamp
-      * value that is in the past MUST NOT be processed.
-    */
-    let error = null;
-    const options = commonOptions(generatorOptions);
-    options.args['headers'] = 'date';
-    options.args['expires'] = util.getUnixTime() - 1000;
-    try {
-      await util.generate('default-test', options);
-    } catch(e) {
-      error = e;
-    }
-    error.should.not.be.null;
-  });
   describe('optional Private Keys', function() {
     privateKeys.forEach(key => {
       it(`should sign with a/an ${key} private key.`, async function() {

--- a/test/latest/20-sign.js
+++ b/test/latest/20-sign.js
@@ -128,7 +128,6 @@ describe('Sign', function() {
     });
   });
 
-
   it(`MUST NOT process a Signature with a
       created timestamp value that is in the future.`, async function() {
     /**

--- a/test/latest/30-verify.js
+++ b/test/latest/30-verify.js
@@ -3,6 +3,7 @@ const {registry, keys} = require('./input/algorithms');
 const util = require('./util');
 const path = require('path');
 const {expect} = require('chai');
+const {algorithms} = require('./input/algorithms');
 
 const publicKeys = Object.keys(keys.public);
 const commonRequest = 'rsa-signed';
@@ -128,7 +129,87 @@ describe('Verify', function() {
     }
     expect(error, 'Expected an error to be thrown').to.not.be.null;
   });
+  ['created', 'expires']
+    .forEach(param => {
+      const unDefined = `If the '${param}' Signature Parameter is
+      not specified, an implementation MUST produce an error.`;
+      it(unDefined, async function() {
+        /**
+            * If the `created` Signature Parameter is
+            * not specified, or is not an integer, an implementation MUST
+            * produce an error.
+          */
+        /**
+          * If the `expires` Signature Parameter is
+          * not specified, or is not an integer, an implementation MUST
+          * produce an error.
+        */
+        generatorOptions.args.headers = [`(${param})`];
+        let error = null;
+        try {
+          await util.generate(`not-${param}`, generatorOptions);
+        } catch(e) {
+          error = e;
+        }
+        expect(error, 'expected and error to be thrown').to.exist;
+      });
+      const notInt = `If the ${param} Signature Parameter is
+      not an integer or unix timestamp, an
+      implementation MUST produce an error.`;
+      it(notInt, async function() {
+        /**
+          * If the `created` Signature Parameter is
+          * not specified, or is not an integer, an implementation MUST
+          * produce an error.
+        */
+        /**
+          * If the `expires` Signature Parameter is
+          * not specified, or is not an integer, an implementation MUST
+          * produce an error.
+        */
+        generatorOptions.args.headers = [`(${param})`];
+        generatorOptions.args[param] = 'not-an-integer';
+        let error = null;
+        try {
+          await util.generate(
+            'basic-request', generatorOptions);
+        } catch(e) {
+          error = e;
+        }
+        expect(error, 'Expected an error to be thrown').to.exist;
+      });
+    });
+
   describe('Algorithm Parameter', function() {
+    ['created', 'expires'].forEach(param => {
+      algorithms.forEach(algorithm => {
+        const algTest = `If (${param}) is in headers & the ` +
+        `algorithm param starts with ${algorithm}` +
+        ' MUST produce an error.';
+        it(algTest, async function() {
+          /**
+           * If the header field name is `(created)` and the `algorithm`
+           * parameter starts with `rsa`, `hmac`, or `ecdsa`
+           * an implementation MUST produce an error.
+          */
+          /**
+           * If the header field name is `(expires)` and the `algorithm`
+           * parameter starts with `rsa`, `hmac`, or `ecdsa`
+           * an implementation MUST produce an error.
+          */
+          generatorOptions.args.headers = [`(${algorithm})`];
+          let error = null;
+          try {
+            await util.generate(
+              `created-${algorithm}`, generatorOptions);
+          } catch(e) {
+            error = e;
+          }
+          expect(error, 'expected an error').to.exist;
+        });
+      });
+    });
+
     it(`MUST produce an error if algorithm
         parameter differs from key metadata.`, async function() {
       /**

--- a/test/latest/30-verify.js
+++ b/test/latest/30-verify.js
@@ -180,6 +180,42 @@ describe('Verify', function() {
       });
     });
 
+  it(`MUST NOT process a Signature with a
+      created timestamp value that is in the future.`, async function() {
+    /**
+     * A signature with a `created` timestamp value
+     * that is in the future MUST NOT be processed.
+    */
+    let error = null;
+    const options = commonOptions(generatorOptions);
+    options.args['headers'] = 'date';
+    options.args['created'] = util.getUnixTime() + 1000;
+    try {
+      await util.generate('default-test', options);
+    } catch(e) {
+      error = e;
+    }
+    expect(error, 'Expected an Error').to.not.be.null;
+  });
+
+  it(`MUST NOT process a Signature with an expires
+      timestamp value that is in the past.`, async function() {
+    /**
+      * A signatures with a `expires` timestamp
+      * value that is in the past MUST NOT be processed.
+    */
+    let error = null;
+    const options = commonOptions(generatorOptions);
+    options.args['headers'] = 'date';
+    options.args['expires'] = util.getUnixTime() - 1000;
+    try {
+      await util.generate('default-test', options);
+    } catch(e) {
+      error = e;
+    }
+    error.should.not.be.null;
+  });
+
   describe('Algorithm Parameter', function() {
     ['created', 'expires'].forEach(param => {
       algorithms.forEach(algorithm => {

--- a/test/latest/30-verify.js
+++ b/test/latest/30-verify.js
@@ -3,7 +3,6 @@ const {registry, keys} = require('./input/algorithms');
 const util = require('./util');
 const path = require('path');
 const {expect} = require('chai');
-const {algorithms} = require('./input/algorithms');
 
 const publicKeys = Object.keys(keys.public);
 const commonRequest = 'rsa-signed';
@@ -217,34 +216,6 @@ describe('Verify', function() {
   });
 
   describe('Algorithm Parameter', function() {
-    ['created', 'expires'].forEach(param => {
-      algorithms.forEach(algorithm => {
-        const algTest = `If (${param}) is in headers & the ` +
-        `algorithm param starts with ${algorithm}` +
-        ' MUST produce an error.';
-        it(algTest, async function() {
-          /**
-           * If the header field name is `(created)` and the `algorithm`
-           * parameter starts with `rsa`, `hmac`, or `ecdsa`
-           * an implementation MUST produce an error.
-          */
-          /**
-           * If the header field name is `(expires)` and the `algorithm`
-           * parameter starts with `rsa`, `hmac`, or `ecdsa`
-           * an implementation MUST produce an error.
-          */
-          generatorOptions.args.headers = [`(${algorithm})`];
-          let error = null;
-          try {
-            await util.generate(
-              `created-${algorithm}`, generatorOptions);
-          } catch(e) {
-            error = e;
-          }
-          expect(error, 'expected an error').to.exist;
-        });
-      });
-    });
 
     it(`MUST produce an error if algorithm
         parameter differs from key metadata.`, async function() {

--- a/test/latest/util.js
+++ b/test/latest/util.js
@@ -62,7 +62,7 @@ function streamToString(stream) {
 }
 
 /**
- * Takes in a javascript ms timestamp and turns it in a unix
+ * Takes in a javascript ms timestamp and converts it to an unix
  *  timestamp in seconds.
  *
  * @param {object} options - Options to use.
@@ -71,6 +71,7 @@ function streamToString(stream) {
  * @returns {number} Number of seconds since epoch.
 */
 function getUnixTime({time = Date.now()} = {}) {
+  // in the case of NaN return 0
   return Math.floor(time / 1000) | 0;
 }
 

--- a/test/latest/util.js
+++ b/test/latest/util.js
@@ -61,8 +61,17 @@ function streamToString(stream) {
   });
 }
 
+/**
+ * Takes in a javascript ms timestamp and turns it in a unix
+ *  timestamp in seconds.
+ *
+ * @param {object} options - Options to use.
+ * @param {number} [options.time=Date.now()] - Number of Ms since epoch.
+ *
+ * @returns {number} Number of seconds since epoch.
+*/
 function getUnixTime({time = Date.now()} = {}) {
-  return time / 1000 | 0;
+  return Math.floor(time / 1000) | 0;
 }
 
 module.exports = {


### PR DESCRIPTION
This moves all the tests for `created` and `expires` pseudo-header parameters to the verify test suite.
We're doing this because it makes more sense than having it in canonicalization or sign.
When verifying, we should ensure `created` and `expires` are valid, but not all implementations might validate inputs to canonicalization and while it's good practice to do this before signing, it is not strictly necessary and also makes it more difficult to produced invalid test data.