### PR TITLE
Add test for unknown algorithm.

### DIFF
--- a/test/latest/10-canonicalize.js
+++ b/test/latest/10-canonicalize.js
@@ -219,7 +219,7 @@ describe('Canonicalize', function() {
         result.should.equal(expected, 'expected signature string to match');
       });
 
-      it('SHOULD return "" if the headers paramter is empty.',
+      it('SHOULD return "" if the headers parameter is empty.',
         async function() {
           generatorOptions.args.headers = ' ';
           const result = await util.generate(

--- a/test/latest/30-verify.js
+++ b/test/latest/30-verify.js
@@ -243,9 +243,8 @@ describe('Verify', function() {
         HTTP Signatures Algorithms Registry.`, async function() {
       let error = null;
       const options = commonOptions(generatorOptions);
-      options.args.algorithm = 'unknown';
       try {
-        await util.generate(commonRequest, options);
+        await util.generate('unknown-algorithm', options);
       } catch(e) {
         error = e;
       }

--- a/test/latest/input/unknown-algorithm.httpMessage
+++ b/test/latest/input/unknown-algorithm.httpMessage
@@ -1,0 +1,6 @@
+GET /basic/request HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+Content-Length: 18
+Authorization: Signature keyId="test",algorithm="unknown",headers="host digest",signature="G/q271XxN9vXgC4/PZj++CIA1tPRIejyrEv+Xji1JunhlVYgNVnMn13TFa47ierVyHZO+5XQV43J9m/n4gbuEwSj87x2fnp0kV82k1VaXmhpiBHaQ123jK9xToynmcIynrkj2MGCCfTotLf1Z4lCP3Eb2G3K76C+npgWNC0I44g="


### PR DESCRIPTION
This fixes a broken test in verification. Instead of using the algorithm passed in as a command line argument, it instead passes in a bad algorithm using the httpMessage. I will mark this ready when I have checked all of the other tests to ensure this error is not in other tests.